### PR TITLE
Adds a graphviz example to asciidoc-diagram-to-html-example

### DIFF
--- a/asciidoc-diagram-to-html-example/src/docs/asciidoc/example-manual.adoc
+++ b/asciidoc-diagram-to-html-example/src/docs/asciidoc/example-manual.adoc
@@ -71,6 +71,34 @@ produces
      +-----------------------------------+
 ----
 
+Next demo is a graphviz block. This requires graphviz to be installed in the system.
+
+.Basic graphviz block
+[source]
+----
+[graphviz]
+....
+digraph g {
+    a -> b
+    b -> c
+    c -> d
+    d -> a
+}
+....
+----
+
+produces:
+
+[graphviz]
+----
+digraph g {
+    a -> b
+    b -> c
+    c -> d
+    d -> a
+}
+----
+
 == build.gradle
 
 [source,groovy]


### PR DESCRIPTION
I did not realized first that I need to install graphviz manually on my system. An example in the Gradle example repo would have helped me.