### PR TITLE
Defined an idprefix to avoid reveal.js bug

### DIFF
--- a/asciidoc-to-revealjs-example/build.gradle
+++ b/asciidoc-to-revealjs-example/build.gradle
@@ -81,7 +81,7 @@ asciidoctor {
 				'toc': 'left',
 				'icons': 'font',
 				'setanchors': '',
-				'idprefix': '',
+				'idprefix': 'slide-',
 				'idseparator': '-',
 				'docinfo1': '',
 				'revealjs_theme': 'black',


### PR DESCRIPTION
There is a bug in reveal.js that causes problems, when ids start with non-ascii-characters, although it is perfectly legal html5. Setting the ``idprefix`` avoids this problem and I think therefore this should be used as the default in the example.

See also:
hakimel/reveal.js#1346
hakimel/reveal.js#1230
asciidoctor/asciidoctor-reveal.js#32
