### PR TITLE
Fix #40: Unblock reveal.js example by pegging asciidoctor-reveal.js version

### DIFF
--- a/asciidoc-to-revealjs-example/build.gradle
+++ b/asciidoc-to-revealjs-example/build.gradle
@@ -19,7 +19,7 @@ version = '1.0.0-SNAPSHOT'
 
 ext {
     revealjsVersion = '3.3.0'
-    asciidoctorBackendVersion = 'master'
+    asciidoctorBackendVersion = '1.0.4'
     downloadDir = new File(buildDir,'download')
     templateDir = new File(downloadDir,'templates')
     revealjsDir   = new File(downloadDir,'reveal.js')
@@ -38,7 +38,7 @@ task download {
     doLast {
         mkdir downloadDir
         vfs {
-            cp "zip:https://github.com/asciidoctor/asciidoctor-reveal.js/archive/${asciidoctorBackendVersion}.zip!asciidoctor-reveal.js-${asciidoctorBackendVersion}",
+            cp "zip:https://github.com/asciidoctor/asciidoctor-reveal.js/archive/v${asciidoctorBackendVersion}.zip!asciidoctor-reveal.js-${asciidoctorBackendVersion}",
             templateDir, recursive:true, overwrite:true
             cp "zip:https://github.com/hakimel/reveal.js/archive/${revealjsVersion}.zip!reveal.js-${revealjsVersion}",
             revealjsDir, recursive:true, overwrite:true


### PR DESCRIPTION
Hi guys. I cloned the repo today and had the same symptoms shown in issue #40.

Something must have changed in the past six months in the master branch of 
asciidoctor/asciidoctor-reveal.js which breaks the asciidoc-to-revealjs-example here. All I did is peg the version to the latest release tag, `v.1.0.4`.

Sorry this isn't really a fix, but rather a workaround!