### PR TITLE
fix #40: use asciidoctor-revealjs gem

### DIFF
--- a/asciidoc-to-revealjs-example/build.gradle
+++ b/asciidoc-to-revealjs-example/build.gradle
@@ -32,14 +32,14 @@ repositories {
 dependencies {
     gems 'rubygems:slim:3.0.8'
     gems 'rubygems:thread_safe:0.3.5'
+    gems 'rubygems:asciidoctor-revealjs:1.0.4'
+
 }
 
 task download {
     doLast {
         mkdir downloadDir
         vfs {
-            cp "zip:https://github.com/asciidoctor/asciidoctor-reveal.js/archive/${asciidoctorBackendVersion}.zip!asciidoctor-reveal.js-${asciidoctorBackendVersion}",
-            templateDir, recursive:true, overwrite:true
             cp "zip:https://github.com/hakimel/reveal.js/archive/${revealjsVersion}.zip!reveal.js-${revealjsVersion}",
             revealjsDir, recursive:true, overwrite:true
         }
@@ -53,7 +53,7 @@ download {
 }
 
 asciidoctorj {
-  version = '1.5.5'
+  version = '1.5.4'
 }
 
 asciidoctor {
@@ -69,6 +69,8 @@ asciidoctor {
             include 'reveal.js/**'
         }
     }
+    gemPath = jrubyPrepare.outputDir
+    requires = ['asciidoctor-revealjs']
     backends 'revealjs'
     attributes \
         'build-gradle': file('build.gradle'),
@@ -86,5 +88,4 @@ asciidoctor {
         'revealjs_transition': 'linear',
         'revealjs_history': 'true',
         'revealjs_slideNumber': 'true'
-    options template_dirs: [new File(templateDir,'templates/slim').absolutePath]
 }


### PR DESCRIPTION
This PR attempts to fix the issue reported by @jeffbrown in #40.

In response to the issue, @mojavelinux said 

> The reveal converter is no longer a loose collection of templates. It's now a real Asciidoctor converter. Thus, we should use it like one. That means depending on a release version of the gem, adding it to the load path, and setting the backend option to "revealjs". This example has simply fallen behind.

This PR pulls in `rubygems:asciidoctor-revealjs:1.0.4` as a gem dependency, and makes it available on the path. 

**It must be noted that I had to downgrade `asciidoctorj` to version `1.5.4` because without the downgrade, I get the following error**

```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':asciidoctor'.
> (ConflictError) Unable to activate asciidoctor-revealjs-1.0.4, because asciidoctor-1.5.5 conflicts with asciidoctor (= 1.5.4)
```

Please let me know if if there is anything else I can provide, or if I am completely off base :)