### PR TITLE
Workaround for lasagna.io error during build, removed backend reveal.js

### DIFF
--- a/asciidoc-diagram-to-html-example/build.gradle
+++ b/asciidoc-diagram-to-html-example/build.gradle
@@ -8,6 +8,11 @@ apply plugin: 'org.asciidoctor.convert'
 
 version = '1.0.0-SNAPSHOT'
 
+repositories {
+    mavenLocal()
+    maven { url 'http://rubygems-proxy.torquebox.org/releases' }
+}
+
 dependencies {
     gems 'rubygems:asciidoctor-diagram:1.5.4'
 }

--- a/asciidoc-to-deckjs-example/build.gradle
+++ b/asciidoc-to-deckjs-example/build.gradle
@@ -26,7 +26,8 @@ ext {
 }
 
 repositories {
-    jcenter()
+    mavenLocal()
+    maven { url 'http://rubygems-proxy.torquebox.org/releases'  }
 }
 
 dependencies {

--- a/asciidoc-to-pdf-with-theme-example/build.gradle
+++ b/asciidoc-to-pdf-with-theme-example/build.gradle
@@ -1,6 +1,7 @@
 buildscript {
     repositories {
-        jcenter()
+        mavenLocal()
+        maven { url 'http://rubygems-proxy.torquebox.org/releases'  }
     }
 
     dependencies {

--- a/asciidoc-to-pdf-with-theme-example/build.gradle
+++ b/asciidoc-to-pdf-with-theme-example/build.gradle
@@ -5,13 +5,13 @@ buildscript {
     }
 
     dependencies {
-        classpath 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.3'
+        classpath 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.8'
         classpath 'org.asciidoctor:asciidoctorj-pdf:1.5.0-alpha.15'
     }
 }
 
 plugins {
-    id 'org.asciidoctor.convert' version '1.5.3'
+    id 'org.asciidoctor.convert' version '1.5.8'
 }
 
 apply plugin: 'java'

--- a/asciidoc-to-revealjs-example/build.gradle
+++ b/asciidoc-to-revealjs-example/build.gradle
@@ -26,7 +26,8 @@ ext {
 }
 
 repositories {
-    jcenter()
+    mavenLocal()
+    maven { url 'http://rubygems-proxy.torquebox.org/releases' }
 }
 
 dependencies {
@@ -69,7 +70,6 @@ asciidoctor {
             include 'reveal.js/**'
         }
     }
-    backends 'revealjs'
     attributes \
         'build-gradle': file('build.gradle'),
         'sourcedir': project.sourceSets.main.java.srcDirs[0],

--- a/finalize.gradle
+++ b/finalize.gradle
@@ -1,6 +1,7 @@
 buildscript {
     repositories {
-        jcenter()
+        mavenLocal()
+        maven { url 'http://rubygems-proxy.torquebox.org/releases'  }
     }
 
     dependencies {

--- a/finalize.gradle
+++ b/finalize.gradle
@@ -2,10 +2,11 @@ buildscript {
     repositories {
         mavenLocal()
         maven { url 'http://rubygems-proxy.torquebox.org/releases'  }
+        jcenter()
     }
 
     dependencies {
-        classpath 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.3'
+        classpath 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.8'
     }
 }
 


### PR DESCRIPTION
I got errors during build, that rubygems.lasagna.io is not found -> domain is sold

After workaround with maven repository I got errors with revealjs backend. Removed it and the presentation is built successfully.