### PR TITLE
Removes `apply plugin` where Plugins DSL is used; fixed two failing builds

### DIFF
--- a/asciidoc-diagram-to-html-example/build.gradle
+++ b/asciidoc-diagram-to-html-example/build.gradle
@@ -1,10 +1,13 @@
 plugins {
-    id 'org.asciidoctor.convert' version '1.5.3'
+    id 'org.asciidoctor.convert' version '1.5.8.1'
     id 'com.github.jruby-gradle.base' version '1.4.0'
 }
 
+repositories {
+    maven { url "http://rubygems-proxy.torquebox.org/releases" }
+}
+
 apply plugin: 'java'
-apply plugin: 'org.asciidoctor.convert'
 
 version = '1.0.0-SNAPSHOT'
 

--- a/asciidoc-to-all-example/build.gradle
+++ b/asciidoc-to-all-example/build.gradle
@@ -6,11 +6,10 @@ buildscript {
 }
 
 plugins {
-  id 'org.asciidoctor.convert' version '1.5.3'
+  id 'org.asciidoctor.convert' version '1.5.8.1'
 }
 
 apply plugin: 'java'
-apply plugin: 'org.asciidoctor.convert'
 
 version = '1.0.0-SNAPSHOT'
 

--- a/asciidoc-to-deckjs-example/build.gradle
+++ b/asciidoc-to-deckjs-example/build.gradle
@@ -6,14 +6,13 @@ buildscript {
 }
 
 plugins {
-    id 'org.asciidoctor.convert' version '1.5.3'
+    id 'org.asciidoctor.convert' version '1.5.8.1'
     id 'com.github.jruby-gradle.base' version '1.4.0'
 }
 
-apply plugin: 'com.github.jruby-gradle.base'
+
 apply plugin: 'org.ysb33r.vfs'
 apply plugin: 'java'
-apply plugin: 'org.asciidoctor.convert'
 
 version = '1.0.0-SNAPSHOT'
 
@@ -27,6 +26,7 @@ ext {
 
 repositories {
     jcenter()
+    maven { url "http://rubygems-proxy.torquebox.org/releases" }
 }
 
 dependencies {

--- a/asciidoc-to-epub3-example/build.gradle
+++ b/asciidoc-to-epub3-example/build.gradle
@@ -5,11 +5,10 @@ buildscript {
 }
 
 plugins {
-    id 'org.asciidoctor.convert' version '1.5.3'
+    id 'org.asciidoctor.convert' version '1.5.8.1'
 }
 
 apply plugin: 'java'
-apply plugin: 'org.asciidoctor.convert'
 
 version = '1.0.0-SNAPSHOT'
 

--- a/asciidoc-to-github-pages-example/build.gradle
+++ b/asciidoc-to-github-pages-example/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'org.ajoberstar.github-pages' version '1.5.1'
     id 'org.asciidoctor.gradle.asciidoctor' version '1.5.1'
-    id 'org.asciidoctor.convert' version '1.5.3'
+    id 'org.asciidoctor.convert' version '1.5.8.1'
 }
 
 githubPages {

--- a/asciidoc-to-html-example/build.gradle
+++ b/asciidoc-to-html-example/build.gradle
@@ -1,9 +1,8 @@
 plugins {
-    id 'org.asciidoctor.convert' version '1.5.3'
+    id 'org.asciidoctor.convert' version '1.5.8.1'
 }
 
 apply plugin: 'java'
-apply plugin: 'org.asciidoctor.convert'
 
 version = '1.0.0-SNAPSHOT'
 

--- a/asciidoc-to-html-livereload-example/build.gradle
+++ b/asciidoc-to-html-livereload-example/build.gradle
@@ -1,10 +1,9 @@
 plugins {
-    id 'org.asciidoctor.convert' version '1.5.3'
+    id 'org.asciidoctor.convert' version '1.5.8.1'
     id 'org.kordamp.gradle.livereload' version '0.2.1'
 }
 
 apply plugin: 'java'
-apply plugin: 'org.asciidoctor.convert'
 apply plugin: 'org.kordamp.gradle.livereload'
 
 version = '1.0.0-SNAPSHOT'

--- a/asciidoc-to-pdf-example/build.gradle
+++ b/asciidoc-to-pdf-example/build.gradle
@@ -5,11 +5,10 @@ buildscript {
 }
 
 plugins {
-    id 'org.asciidoctor.convert' version '1.5.3'
+    id 'org.asciidoctor.convert' version '1.5.8.1'
 }
 
 apply plugin: 'java'
-apply plugin: 'org.asciidoctor.convert'
 
 version = '1.0.0-SNAPSHOT'
 

--- a/asciidoc-to-pdf-with-theme-example/build.gradle
+++ b/asciidoc-to-pdf-with-theme-example/build.gradle
@@ -4,17 +4,16 @@ buildscript {
     }
 
     dependencies {
-        classpath 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.3'
+        classpath 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.8.1'
         classpath 'org.asciidoctor:asciidoctorj-pdf:1.5.0-alpha.15'
     }
 }
 
 plugins {
-    id 'org.asciidoctor.convert' version '1.5.3'
+    id 'org.asciidoctor.convert' version '1.5.8.1'
 }
 
 apply plugin: 'java'
-apply plugin: 'org.asciidoctor.convert'
 
 asciidoctorj {
     version = '1.5.5'

--- a/asciidoc-to-revealjs-example/build.gradle
+++ b/asciidoc-to-revealjs-example/build.gradle
@@ -6,14 +6,12 @@ buildscript {
 }
 
 plugins {
-  id 'org.asciidoctor.convert' version '1.5.3'
+  id 'org.asciidoctor.convert' version '1.5.8.1'
   id 'com.github.jruby-gradle.base' version '1.4.0'
 }
 
-apply plugin: 'com.github.jruby-gradle.base'
 apply plugin: 'org.ysb33r.vfs'
 apply plugin: 'java'
-apply plugin: 'org.asciidoctor.convert'
 
 version = '1.0.0-SNAPSHOT'
 
@@ -27,6 +25,7 @@ ext {
 
 repositories {
     jcenter()
+    maven { url "http://rubygems-proxy.torquebox.org/releases" }
 }
 
 dependencies {
@@ -86,5 +85,5 @@ asciidoctor {
         'revealjs_transition': 'linear',
         'revealjs_history': 'true',
         'revealjs_slideNumber': 'true'
-    options template_dirs: [new File(templateDir,'templates/slim').absolutePath]
+    options template_dirs: [new File(templateDir,'templates').absolutePath]
 }


### PR DESCRIPTION
* Removes `apply plugin` where the Plugins DSL is used
* Fixes issue #38 
* Fixes the same issue as asciidoctor/asciidoctor-maven-examples#62 in Gradle
* Upgrades asciidoctor-gradle-plugin to a more recent version
