### PR TITLE
Unable to install openjdk8 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 language: java
 
 jdk:


### PR DESCRIPTION
Expected feature release number in range of 9 to 15, but got: 8