### PR TITLE
Fix various issues with the reveal.js example

### DIFF
--- a/asciidoc-to-revealjs-example/README.adoc
+++ b/asciidoc-to-revealjs-example/README.adoc
@@ -14,4 +14,4 @@ If you're using IntelliJ you can generate the IDE's files via:
 
  $ ./gradlew idea
 
-Open the file _build/asciidoc/reveal/example-manual.html_ in your browser to see the generated revealjs file.
+Open the file _build/docs/asciidocRevealJs/example-deck.html_ in your browser to see the generated reveal.js file.

--- a/asciidoc-to-revealjs-example/build.gradle
+++ b/asciidoc-to-revealjs-example/build.gradle
@@ -40,6 +40,7 @@ asciidoctorRevealJs {
     attributes 'build-gradle': file('build.gradle'),
             'endpoint-url': 'http://example.org',
             'source-highlighter': 'coderay',
+            'coderay-css': 'style',
             'imagesdir': './images',
             'toc': 'left',
             'icons': 'font',

--- a/asciidoc-to-revealjs-example/build.gradle
+++ b/asciidoc-to-revealjs-example/build.gradle
@@ -28,6 +28,8 @@ revealjs {
 asciidoctorRevealJs {
     sourceDir file("src/docs/asciidoc")
 
+    baseDirFollowsSourceFile()
+
     resources {
         from("${sourceDir}/images") {
             include '**'
@@ -44,7 +46,7 @@ asciidoctorRevealJs {
             'setanchors': '',
             'idprefix': 'slide-',
             'idseparator': '-',
-            'docinfo1': '',
+            'docinfo': 'shared',
             'revealjs_theme': 'black',
             'revealjs_transition': 'linear',
             'revealjs_history': 'true',

--- a/asciidoc-to-revealjs-example/src/docs/asciidoc/example-deck.adoc
+++ b/asciidoc-to-revealjs-example/src/docs/asciidoc/example-deck.adoc
@@ -1,9 +1,9 @@
 = Example Deck
 Doc Writer <doc.writer@example.org>
-2014-09-09
+2020-02-07
 :example-caption!:
-ifndef::imagesdir[:imagesdir: images]
-ifndef::sourcedir[:sourcedir: ../java]
+:imagesdir: images
+:sourcedir: ../../main/java
 
 == Introduction
 

--- a/asciidoc-to-revealjs-example/src/docs/asciidoc/example-deck.adoc
+++ b/asciidoc-to-revealjs-example/src/docs/asciidoc/example-deck.adoc
@@ -1,7 +1,6 @@
 = Example Deck
 Doc Writer <doc.writer@example.org>
 2014-09-09
-:revnumber: {project-version}
 :example-caption!:
 ifndef::imagesdir[:imagesdir: images]
 ifndef::sourcedir[:sourcedir: ../java]
@@ -70,7 +69,7 @@ imagesdir:: {imagesdir}
 
 === Attributes Part 2
 .Custom
-project-version:: {project-version}
+revnumber:: {revnumber}
 sourcedir:: {sourcedir}
 endpoint-url:: {endpoint-url}
 


### PR DESCRIPTION
I've noticed a few issues with the reveal.js example:
- includes were not resolved
- `project-version` was renamed to `revnumber` in 3.x: https://asciidoctor.github.io/asciidoctor-gradle-plugin/development-3.x/user-guide/#_upgrading_from_older_versions_of_asciidoctor
- Code blocks were using white text on white background
- the relative path was wrong in the .adoc file


![includes](https://user-images.githubusercontent.com/333276/74054946-515ff800-49df-11ea-9dba-f580e1f16cc9.png)
![coderay-style](https://user-images.githubusercontent.com/333276/74054948-51f88e80-49df-11ea-84ef-7d0d4782542e.png)
![source-include](https://user-images.githubusercontent.com/333276/74054954-57ee6f80-49df-11ea-8788-565a2f72f9d3.png)

And it's even working when converting the AsciiDoc document using the browser extension:

![ok](https://user-images.githubusercontent.com/333276/74054943-50c76180-49df-11ea-9f78-f7787c3c9e99.png)
